### PR TITLE
Config fix for dependent repositories

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -51,7 +51,7 @@
     },
     {
       "path_to_root": "_themes",
-      "url": "https://github.com/Microsoft/templates.docs.msft.zh-CH",
+      "url": "https://github.com/Microsoft/templates.docs.msft.zh-CN",
       "branch": "master",
       "branch_mapping": {}
     },


### PR DESCRIPTION
Fix the configuration to make it consistent with the live branch: https://github.com/OfficeDev/office-scripts-docs-reference.zh-CN/blob/live/.openpublishing.publish.config.json#L40